### PR TITLE
Use recognized readme/header metadata

### DIFF
--- a/feature-policy.php
+++ b/feature-policy.php
@@ -16,10 +16,9 @@
  * License:     GNU General Public License v2 (or later)
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: feature-policy
- * Tags:        feature, policy
  */
 
-/* This file must be parseable by PHP 5.2. */
+/* This file must be parsable by PHP 5.2. */
 
 /**
  * Loads the plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -1,15 +1,10 @@
 === Feature Policy ===
 
-Plugin Name:       Feature Policy
-Plugin URI:        https://wordpress.org/plugins/feature-policy/
-Author:            Google
-Author URI:        https://opensource.google.com/
 Contributors:      google, westonruter, flixos90
 Requires at least: 4.7
 Tested up to:      5.0
 Requires PHP:      5.6
 Stable tag:        0.1.0
-Version:           0.1.0
 License:           GNU General Public License v2 (or later)
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              feature, policy


### PR DESCRIPTION
The `readme.txt` metadata and plugin header metadata have different lists of recognized fields:

https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/
https://developer.wordpress.org/plugins/the-basics/header-requirements/

This de-duplicates the metadata.